### PR TITLE
Show folder size in real time

### DIFF
--- a/src/ui/components/DeleteDialog.tsx
+++ b/src/ui/components/DeleteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useCallback } from "react"
+import React, { Dispatch, SetStateAction, useCallback, useMemo } from "react"
 import { ModalState, QueryParams } from "@/ui/types"
 import Button from "@mui/material/Button"
 import Dialog from "@mui/material/Dialog"
@@ -8,6 +8,8 @@ import DialogContentText from "@mui/material/DialogContentText"
 import DialogTitle from "@mui/material/DialogTitle"
 
 import { useDeleteFile } from "@/ui/hooks/queryhooks"
+import { useQueryClient } from "@tanstack/react-query"
+import { getSortOrder } from "../utils/common"
 
 type DeleteDialogProps = {
   modalState: Partial<ModalState>
@@ -21,9 +23,24 @@ export default function DeleteDialog({
 }: DeleteDialogProps) {
   const { mutation: deleteMutation } = useDeleteFile(queryParams)
 
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => {
+    const { key, path } = queryParams
+    const sortOrder = getSortOrder()
+    const queryKey = [key, path, sortOrder]
+    return queryKey
+  }, [queryParams])
+
   const handleClose = useCallback((denyDelete = true) => {
     if (!denyDelete) deleteMutation.mutate({ files: modalState.selectedFiles })
     setModalState((prev) => ({ ...prev, open: false }))
+
+    const path = queryKey[1];
+      for (let i = path.length; i > 0; i--) {
+        const partialPath = path.slice(0, i);
+        const updatedQueryKey = ["files", partialPath, queryKey[2]];
+        queryClient.refetchQueries(updatedQueryKey);
+      }
   }, [])
 
   return (

--- a/src/ui/components/DeleteDialog.tsx
+++ b/src/ui/components/DeleteDialog.tsx
@@ -8,8 +8,6 @@ import DialogContentText from "@mui/material/DialogContentText"
 import DialogTitle from "@mui/material/DialogTitle"
 
 import { useDeleteFile } from "@/ui/hooks/queryhooks"
-import { useQueryClient } from "@tanstack/react-query"
-import { getSortOrder } from "../utils/common"
 
 type DeleteDialogProps = {
   modalState: Partial<ModalState>
@@ -23,23 +21,12 @@ export default function DeleteDialog({
 }: DeleteDialogProps) {
   const { mutation: deleteMutation } = useDeleteFile(queryParams)
 
-  const queryClient = useQueryClient();
-  const queryKey = useMemo(() => {
-    const { key, path } = queryParams
-    const sortOrder = getSortOrder()
-    const queryKey = [key, path, sortOrder]
-    return queryKey
-  }, [queryParams])
-
   const handleClose = useCallback((denyDelete = true) => {
-    if (!denyDelete) deleteMutation.mutate({ files: modalState.selectedFiles })
-    setModalState((prev) => ({ ...prev, open: false }))
-
-    const path = queryParams.path as string[];
-    for (let i = path.length; i > 0; i--) {
-      const partialPath = path.slice(0, i);
-      const updatedQueryKey = ["files", partialPath, queryKey[2]];
-      queryClient.refetchQueries(updatedQueryKey);
+    if (!denyDelete) {
+      deleteMutation.mutate({ files: modalState.selectedFiles });
+      setModalState((prev) => ({ ...prev, open: false, successful: true, }))
+    } else {
+      setModalState((prev) => ({ ...prev, open: false }))
     }
   }, [])
 

--- a/src/ui/components/DeleteDialog.tsx
+++ b/src/ui/components/DeleteDialog.tsx
@@ -35,12 +35,12 @@ export default function DeleteDialog({
     if (!denyDelete) deleteMutation.mutate({ files: modalState.selectedFiles })
     setModalState((prev) => ({ ...prev, open: false }))
 
-    const path = queryKey[1];
-      for (let i = path.length; i > 0; i--) {
-        const partialPath = path.slice(0, i);
-        const updatedQueryKey = ["files", partialPath, queryKey[2]];
-        queryClient.refetchQueries(updatedQueryKey);
-      }
+    const path = queryParams.path as string[];
+    for (let i = path.length; i > 0; i--) {
+      const partialPath = path.slice(0, i);
+      const updatedQueryKey = ["files", partialPath, queryKey[2]];
+      queryClient.refetchQueries(updatedQueryKey);
+    }
   }, [])
 
   return (

--- a/src/ui/components/FileBrowser.tsx
+++ b/src/ui/components/FileBrowser.tsx
@@ -233,9 +233,7 @@ const MyFileBrowser = () => {
       for (let i = path.length; i > 0; i--) {
         const partialPath = path.slice(0, i);
         const updatedQueryKey = ["files", partialPath, queryKey[2]];
-        setTimeout(()=> {
-          queryClient.refetchQueries(updatedQueryKey);
-        }, 100)
+        queryClient.invalidateQueries(updatedQueryKey);
       }
     }
   }, [modalState.operation, modalState.successful])

--- a/src/ui/components/FileBrowser.tsx
+++ b/src/ui/components/FileBrowser.tsx
@@ -35,7 +35,7 @@ import {
   SyncFiles,
   UploadFiles,
 } from "@/ui/utils/chonkyactions"
-import { chainLinks, getFiles } from "@/ui/utils/common"
+import { chainLinks, getFiles, getSortOrder } from "@/ui/utils/common"
 
 import DeleteDialog from "./DeleteDialog"
 import ErrorView from "./ErrorView"
@@ -219,6 +219,26 @@ const MyFileBrowser = () => {
         )
     }
   }, [router.asPath])
+
+  const queryKey = useMemo(() => {
+    const { key, path } = queryParams
+    const sortOrder = getSortOrder()
+    const queryKey = [key, path, sortOrder]
+    return queryKey
+  }, [queryParams])
+
+  useEffect(()=>{
+    if (modalState.operation === "delete_file" && modalState.successful) {
+      const path = queryParams.path as string[];
+      for (let i = path.length; i > 0; i--) {
+        const partialPath = path.slice(0, i);
+        const updatedQueryKey = ["files", partialPath, queryKey[2]];
+        setTimeout(()=> {
+          queryClient.refetchQueries(updatedQueryKey);
+        }, 100)
+      }
+    }
+  }, [modalState.operation, modalState.successful])
 
   if (error) {
     return <ErrorView error={error as Error} />

--- a/src/ui/components/UploadBar.tsx
+++ b/src/ui/components/UploadBar.tsx
@@ -571,7 +571,7 @@ const Upload = ({
       }
     }
     if (currentFileIndex !== 0 && currentFileIndex >= files.length) {
-      const path = queryKey[1];
+      const path = queryParams.path as string[];
       for (let i = path.length; i > 0; i--) {
         const partialPath = path.slice(0, i);
         const updatedQueryKey = ["files", partialPath, queryKey[2]];

--- a/src/ui/components/UploadBar.tsx
+++ b/src/ui/components/UploadBar.tsx
@@ -6,7 +6,7 @@ import React, {
   useReducer,
   useRef,
 } from "react"
-import { QueryParams, Settings, UploadPart } from "@/ui/types"
+import { FilePayload, QueryParams, Settings, UploadPart } from "@/ui/types"
 import {
   ChonkyIconFA,
   ColorsLight,
@@ -176,7 +176,7 @@ const UploadItemEntry = memo(
   }: UploadEntryProps) => {
     const { icon, colorCode } = useIconData({ name, isDir: false, id: "" })
 
-    const [hoverRef, isHovered] = useHover()
+    const [hoverRef, isHovered] = useHover<HTMLLIElement>()
 
     const intl = useIntl()
 
@@ -290,7 +290,7 @@ const uploadPart = async <T extends {}>(
 const uploadFile = async (
   file: File,
   path: string,
-  createMutation: UseMutationResult,
+  createMutation: UseMutationResult<any, unknown, FilePayload, unknown>,
   settings: Settings,
   onProgress: (progress: number) => void,
   cancelSignal: AbortSignal
@@ -571,7 +571,12 @@ const Upload = ({
       }
     }
     if (currentFileIndex !== 0 && currentFileIndex >= files.length) {
-      queryClient.invalidateQueries({ queryKey })
+      const path = queryKey[1];
+      for (let i = path.length; i > 0; i--) {
+        const partialPath = path.slice(0, i);
+        const updatedQueryKey = ["files", partialPath, queryKey[2]];
+        queryClient.refetchQueries(updatedQueryKey);
+      }
     }
   }, [files, currentFileIndex])
 

--- a/src/ui/components/UploadBar.tsx
+++ b/src/ui/components/UploadBar.tsx
@@ -575,7 +575,7 @@ const Upload = ({
       for (let i = path.length; i > 0; i--) {
         const partialPath = path.slice(0, i);
         const updatedQueryKey = ["files", partialPath, queryKey[2]];
-        queryClient.refetchQueries(updatedQueryKey);
+        queryClient.invalidateQueries(updatedQueryKey);
       }
     }
   }, [files, currentFileIndex])

--- a/src/ui/types/index.d.ts
+++ b/src/ui/types/index.d.ts
@@ -21,11 +21,21 @@ export type File = {
 
 export type ModalState = {
   open: boolean
-  operation: string
+  operation:
+    | "download_file"
+    | "rename_file"
+    | "delete_file"
+    | "sync_files"
+    | "open_vlc_player"
+    | "copy_link"
+    | "create_folder"
+    | "upload_files"
+    | "open_files"
   type: string
   file: FileData
   selectedFiles: string[]
   name: string
+  successful?: boolean
 }
 
 export type Params = {

--- a/src/ui/utils/chonkyactions.ts
+++ b/src/ui/utils/chonkyactions.ts
@@ -20,7 +20,7 @@ import { getSortOrder, navigateToExternalUrl } from "./common"
 import http from "./http"
 
 export const DownloadFile = defineFileAction({
-  id: "download_file",
+  id: "download_file" as const,
   requiresSelection: true,
   fileFilter: (file) => (file && "isDir" in file ? false : true),
   button: {
@@ -31,7 +31,7 @@ export const DownloadFile = defineFileAction({
 })
 
 export const RenameFile = defineFileAction({
-  id: "rename_file",
+  id: "rename_file" as const,
   requiresSelection: true,
   button: {
     name: "Rename",
@@ -41,7 +41,7 @@ export const RenameFile = defineFileAction({
 })
 
 export const DeleteFile = defineFileAction({
-  id: "delete_file",
+  id: "delete_file" as const,
   requiresSelection: true,
   button: {
     name: "Delete",
@@ -51,7 +51,7 @@ export const DeleteFile = defineFileAction({
 })
 
 export const SyncFiles = defineFileAction({
-  id: "sync_files",
+  id: "sync_files" as const,
   button: {
     name: "Sync Files",
     toolbar: true,
@@ -61,7 +61,7 @@ export const SyncFiles = defineFileAction({
 })
 
 export const OpenInVLCPlayer = defineFileAction({
-  id: "open_vlc_player",
+  id: "open_vlc_player" as const,
   requiresSelection: true,
   fileFilter: (file) =>
     file &&
@@ -77,7 +77,7 @@ export const OpenInVLCPlayer = defineFileAction({
 })
 
 export const CopyDownloadLink = defineFileAction({
-  id: "copy_link",
+  id: "copy_link" as const,
   requiresSelection: true,
   fileFilter: (file) => (file && "isDir" in file ? false : true),
   button: {
@@ -89,7 +89,7 @@ export const CopyDownloadLink = defineFileAction({
 
 export const CreateFolder = (group = "", path = "") =>
   defineFileAction({
-    id: "create_folder",
+    id: "create_folder" as const,
     button: {
       name: "Create folder",
       tooltip: "Create a folder",
@@ -105,7 +105,7 @@ export const CreateFolder = (group = "", path = "") =>
 
 export const UploadFiles = (group = "", path = "") =>
   defineFileAction({
-    id: "upload_files",
+    id: "upload_files" as const,
     button: {
       name: "Upload files",
       tooltip: "Upload files",


### PR DESCRIPTION
Hello again. In this pull request, I've introduced a change to the way query revalidation is handled. Actually, I'm a bit undecided on whether to use invalidateQueries or refetchQueries.

The challenge with invalidateQueries arises when uploading or deleting a file. When navigating back to the parent directory, there's a brief moment where the previous folder size is displayed before updating. That in my opinion is a bad UX. 

On the other hand, using refetchQueries ensures real-time updates to folder sizes, resolving the issue of delayed changes. However, I'm conscious of the potential performance implications of refetching through all parent directories. While this might not be a significant concern, I believe it's essential to address.

**Changes:**
- Transitioned from invalidateQueries to refetchQueries, in the UploadBar component, iterating through an array of paths.
- Implemented the same behavior to DeleteDialog component.
- Fixed some type errors with typescript in the UploadBar file.

Your feedback on this matter would be greatly appreciated. Please review the changes and provide your thoughts on the approach outlined above. Thank you for your time.