### PR TITLE
Add Support Upload Split Limit 100MB for Cloudflare Site

### DIFF
--- a/src/ui/utils/common.ts
+++ b/src/ui/utils/common.ts
@@ -103,6 +103,7 @@ export default function textToSvgURL(text: string) {
 }
 
 export const splitFileSizes = [
+  { value: 100 * 1024 * 1024, label: "100MB" },
   { value: 500 * 1024 * 1024, label: "500MB" },
   { value: 1000 * 1024 * 1024, label: "1GB" },
   { value: 2 * 1000 * 1024 * 1024, label: "2GB" },


### PR DESCRIPTION
As I use Cloudflare and is Limited Upload Size to [100MB](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#upload-limits), I add split size option to 100MB.

