### PR TITLE
Remove newline from clipboardText (Copy link)

### DIFF
--- a/src/hooks/useFileAction.ts
+++ b/src/hooks/useFileAction.ts
@@ -180,11 +180,11 @@ export const useFileAction = (params: QueryParams, session: Session) => {
         case CustomActions.CopyDownloadLink.id: {
           const selections = data.state.selectedFilesForAction
           let clipboardText = ""
-          selections.forEach((element) => {
-            if (!FileHelper.isDirectory(element)) {
+          selections
+            .filter((element)=>!FileHelper.isDirectory(element))
+            .forEach((element, idx, arr) => {
               const { id, name } = element
-              clipboardText = `${clipboardText}${mediaUrl(id, name, session.hash, true)}\n`
-            }
+              clipboardText = `${clipboardText}${mediaUrl(id, name, session.hash, true)}` + (idx+1 < arr.length ? "\n" : "");
           })
           navigator.clipboard.writeText(clipboardText)
           break


### PR DESCRIPTION
Not sure why there's a newline appended to the download link when copying it to the clipboard. Is there a specific reason? I assume there isn't, so this pr removes the newline, as it is rather annoying.