### PR TITLE
fix: Remove forced 16:9 aspect ratio from player

### DIFF
--- a/src/components/previews/video/art-player.tsx
+++ b/src/components/previews/video/art-player.tsx
@@ -16,7 +16,6 @@ export const Player = forwardRef<Artplayer, PlayerProps>(
         ...option,
         container: artRef.current!,
       });
-      art.aspectRatio = "16:9";
       if (ref && typeof ref !== "function") ref.current = art;
       else if (ref && typeof ref === "function") ref(art);
 


### PR DESCRIPTION
## Summary

Removes the hardcoded `16:9` aspect ratio so the player defaults to the video's original aspect ratio.

## Details

Previously the player instance forced a `16:9` aspect ratio:

```ts
art.aspectRatio = "16:9";
```

This caused videos with other aspect ratios (e.g., vertical or 4:3 videos) to render incorrectly in the preview unless users manually changed the aspect ratio from the player settings.

By removing this line, ArtPlayer falls back to its default behavior and automatically uses the video's native aspect ratio.

## Before / After screenshots

### Before
<img  width="1920" height="1080" alt="Screenshot_before" src="https://github.com/user-attachments/assets/52c9af4b-66a1-4f4a-9ef9-e4606d21690c" />

### After
<img width="1920" height="1080" alt="Screenshot_after" src="https://github.com/user-attachments/assets/4483a509-8247-482c-95ec-31e4ca3720b2" />


## Result

- Videos display using their **correct native aspect ratio**
- Vertical videos render properly
- Users can still manually adjust the aspect ratio via player settings
    
